### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Default value is America/New_York .
   
   /var/lib/mysql
   
-  /opt/cacti/rra
+  /rra
 
 ## Accessing the Cacti applications:
 


### PR DESCRIPTION
`/opt/cacti/rra` is now `/rra` since it won't otherwise work