### PR TITLE
fix typo rrd to rra in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ cacti:
    - ./log/:/var/log/
    - ./templates/:/opt/cacti/templates/
    - ./mysql/:/var/lib/mysql/
-   - ./rrd/:/opt/cacti/rrd/
+   - ./rra/:/opt/cacti/rra/


### PR DESCRIPTION
this is to align docker-compose.yml and Dockerfile